### PR TITLE
Update NeutralPackagedFood.hpp

### DIFF
--- a/DayZ_Epoch_11.Chernarus/ZSC/config/Category/NeutralPackagedFood.hpp
+++ b/DayZ_Epoch_11.Chernarus/ZSC/config/Category/NeutralPackagedFood.hpp
@@ -39,11 +39,6 @@ class Category_687 {
 		buy[] ={60,"Coins"};
 		sell[] ={30,"Coins"};
 	};
-	class FoodEdible {
-		type = "trade_items";
-		buy[] ={60,"Coins"};
-		sell[] ={30,"Coins"};
-	};
 };
 class Category_579 {
 	class FoodCanBakedBeans {
@@ -86,10 +81,4 @@ class Category_579 {
 		buy[] ={60,"Coins"};
 		sell[] ={30,"Coins"};
 	};
-	class FoodEdible {
-		type = "trade_items";
-		buy[] ={60,"Coins"};
-		sell[] ={30,"Coins"};
-	};
-
 };


### PR DESCRIPTION
Food Edible does not exist in epoch , or overwatch
