### PR TITLE
Update bank_dialog.sqf

### DIFF
--- a/DayZ_Epoch_11.Chernarus/ZSC/actions/bank_dialog.sqf
+++ b/DayZ_Epoch_11.Chernarus/ZSC/actions/bank_dialog.sqf
@@ -1,4 +1,4 @@
-[spoiler]if(DZE_ActionInProgress) exitWith { cutText [(localize "str_epoch_player_10") , "PLAIN DOWN"]; };
+if(DZE_ActionInProgress) exitWith { cutText [(localize "str_epoch_player_10") , "PLAIN DOWN"]; };
 DZE_ActionInProgress = true;
 
 private ["_dialog"];
@@ -6,4 +6,4 @@ ZSC_CurrentStorage = cursorTarget;
 _dialog = createDialog "BankDialog";
 call BankDialogUpdateAmounts;
 
-DZE_ActionInProgress = false;[/spoiler]
+DZE_ActionInProgress = false;

--- a/DayZ_Epoch_11.Chernarus/ZSC/actions/bank_dialog.sqf
+++ b/DayZ_Epoch_11.Chernarus/ZSC/actions/bank_dialog.sqf
@@ -1,4 +1,9 @@
+[spoiler]if(DZE_ActionInProgress) exitWith { cutText [(localize "str_epoch_player_10") , "PLAIN DOWN"]; };
+DZE_ActionInProgress = true;
+
 private ["_dialog"];
 ZSC_CurrentStorage = cursorTarget;
 _dialog = createDialog "BankDialog";
 call BankDialogUpdateAmounts;
+
+DZE_ActionInProgress = false;[/spoiler]


### PR DESCRIPTION
So this was my fix for the duping of coins when locking safe and quickly going into money menu - feel free to strike down , some one else just came up with another fix aswell, thank you zupa , keep up the good work